### PR TITLE
249169: Update the existing Node Template App to work with updated FFC Helm Library

### DIFF
--- a/helm/ffc-template-node/Chart.yaml
+++ b/helm/ffc-template-node/Chart.yaml
@@ -5,5 +5,5 @@ name: adp-template-node
 version: 1.0.0
 dependencies:
 - name: adp-helm-library
-  version: 4.0.0
+  version: 4.0.1
   repository: https://raw.githubusercontent.com/defra/adp-helm-repository/master/

--- a/helm/ffc-template-node/Chart.yaml
+++ b/helm/ffc-template-node/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-description: description-of-project-goes-here
+description: A chart for Kubernetes
 name: adp-template-node
 # this version is automatically updated in the build pipeline
 version: 1.0.0
 dependencies:
 - name: adp-helm-library
-  version: 4.0.1
+  version: ^4.0.0
   repository: https://raw.githubusercontent.com/defra/adp-helm-repository/master/

--- a/helm/ffc-template-node/templates/_container.yaml
+++ b/helm/ffc-template-node/templates/_container.yaml
@@ -1,6 +1,6 @@
-{{- define "ffc-template-node.container" -}}
-livenessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.livenessProbe) | nindent 4}}
-readinessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.readinessProbe) | nindent 4}}
+{{- define "adp-template-node.container" -}}
+livenessProbe: {{ include "adp-helm-library.http-get-probe" (list . .Values.livenessProbe) | nindent 4}}
+readinessProbe: {{ include "adp-helm-library.http-get-probe" (list . .Values.readinessProbe) | nindent 4}}
 ports:
 - containerPort: {{ .Values.container.port }}
 {{- end -}}

--- a/helm/ffc-template-node/templates/cluster-ip-service.yaml
+++ b/helm/ffc-template-node/templates/cluster-ip-service.yaml
@@ -1,3 +1,3 @@
-{{- include "ffc-helm-library.cluster-ip-service" (list . "ffc-template-node.cluster-ip-service") -}}
+{{- include "adp-helm-library.cluster-ip-service" (list . "ffc-template-node.cluster-ip-service") -}}
 {{- define "ffc-template-node.cluster-ip-service" -}}
 {{- end -}}

--- a/helm/ffc-template-node/templates/container-secret.yaml
+++ b/helm/ffc-template-node/templates/container-secret.yaml
@@ -1,4 +1,4 @@
-{{- include "ffc-helm-library.container-secret" (list . "ffc-template-node.container-secret") -}}
+{{- include "adp-helm-library.container-secret" (list . "ffc-template-node.container-secret") -}}
 {{- define "ffc-template-node.container-secret" -}}
 stringData:
   {{- if .Values.appInsights.connectionString }}

--- a/helm/ffc-template-node/templates/deployment.yaml
+++ b/helm/ffc-template-node/templates/deployment.yaml
@@ -4,5 +4,5 @@ spec:
   template:
     spec:
       containers:
-      - {{ include "adp-helm-library.container" (list . "ffc-template-node.container") }}
+      - {{ include "adp-helm-library.container" (list . "adp-template-node.container") }}
 {{- end -}}

--- a/helm/ffc-template-node/templates/deployment.yaml
+++ b/helm/ffc-template-node/templates/deployment.yaml
@@ -1,8 +1,8 @@
-{{- include "ffc-helm-library.deployment" (list . "ffc-template-node.deployment") -}}
+{{- include "adp-helm-library.deployment" (list . "ffc-template-node.deployment") -}}
 {{- define "ffc-template-node.deployment" -}}
 spec:
   template:
     spec:
       containers:
-      - {{ include "ffc-helm-library.container" (list . "ffc-template-node.container") }}
+      - {{ include "adp-helm-library.container" (list . "ffc-template-node.container") }}
 {{- end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-template-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "description-of-project-goes-here",
   "homepage": "https://github.com/DEFRA/ffc-template-node",
   "main": "app/index.js",


### PR DESCRIPTION
Description
A brief description of changes being made
Updated the existing ffc-node-template to use the new adp-helm-library.  
AB#249169

# **What this PR does / why we need it**:
CI/CD deployment of Helm chart and container image with the use of new ADO pipeline was successfully implemented. 
This will enable the Development team to demo the creation of a service end-to-end using a real template that the development teams are already using.
https://dev.azure.com/defragovuk/DEFRA-FFC/_build/results?buildId=383875&view=results

# Testing
Publishing to ACR will be further checked on portal after ongoing changes to development environment is complete.

- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [x] This PR contains tests

